### PR TITLE
triggering reavis for: Make --dependency accept a component too [WIP]

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -367,6 +367,7 @@ library
     Distribution.Types.Version
     Distribution.Types.VersionRange
     Distribution.Types.VersionInterval
+    Distribution.Types.GivenComponent
     Distribution.Utils.Generic
     Distribution.Utils.NubList
     Distribution.Utils.ShortText

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -434,7 +434,7 @@ configure (pkg_descr0, pbi) cfg = do
     -- that is not possible to configure a test-suite to use one
     -- version of a dependency, and the executable to use another.
     (allConstraints  :: [Dependency],
-     requiredDepsMap :: Map PackageName InstalledPackageInfo)
+     requiredDepsMap :: Map (PackageName, ComponentName) InstalledPackageInfo)
         <- either (die' verbosity) return $
               combinedConstraints (configConstraints cfg)
                                   (configDependencies cfg)
@@ -864,7 +864,7 @@ dependencySatisfiable
     -> PackageName
     -> InstalledPackageIndex -- ^ installed set
     -> Map PackageName (Maybe UnqualComponentName) -- ^ internal set
-    -> Map PackageName InstalledPackageInfo -- ^ required dependencies
+    -> Map (PackageName, ComponentName) InstalledPackageInfo -- ^ required dependencies
     -> (Dependency -> Bool)
 dependencySatisfiable
   use_external_internal_deps
@@ -884,7 +884,7 @@ dependencySatisfiable
         -- Except for internal deps, when we're NOT per-component mode;
         -- those are just True.
         then True
-        else depName `Map.member` requiredDepsMap
+        else (depName, CLibName) `Map.member` requiredDepsMap
 
     | isInternalDep
     = if use_external_internal_deps
@@ -1012,7 +1012,7 @@ configureDependencies
     -> UseExternalInternalDeps
     -> Map PackageName (Maybe UnqualComponentName) -- ^ internal packages
     -> InstalledPackageIndex -- ^ installed packages
-    -> Map PackageName InstalledPackageInfo -- ^ required deps
+    -> Map (PackageName, ComponentName) InstalledPackageInfo -- ^ required deps
     -> PackageDescription
     -> ComponentRequestedSpec
     -> IO [PreExistingComponent]
@@ -1186,7 +1186,7 @@ data FailedDependency = DependencyNotExists PackageName
 selectDependency :: PackageId -- ^ Package id of current package
                  -> Map PackageName (Maybe UnqualComponentName)
                  -> InstalledPackageIndex  -- ^ Installed packages
-                 -> Map PackageName InstalledPackageInfo
+                 -> Map (PackageName, ComponentName) InstalledPackageInfo
                     -- ^ Packages for which we have been given specific deps to
                     -- use
                  -> UseExternalInternalDeps -- ^ Are we configuring a
@@ -1222,7 +1222,7 @@ selectDependency pkgid internalIndex installedIndex requiredDepsMap
 
     -- We have to look it up externally
     do_external is_internal = do
-      ipi <- case Map.lookup dep_pkgname requiredDepsMap of
+      ipi <- case Map.lookup (dep_pkgname, CLibName) requiredDepsMap of
         -- If we know the exact pkg to use, then use it.
         Just pkginstance -> Right pkginstance
         -- Otherwise we just pick an arbitrary instance of the latest version.
@@ -1357,10 +1357,10 @@ interpretPackageDbFlags userInstall specificDBs =
 -- deps in the end. So we still need to remember which installed packages to
 -- pick.
 combinedConstraints :: [Dependency] ->
-                       [(PackageName, ComponentId)] ->
+                       [(PackageName, ComponentName, ComponentId)] ->
                        InstalledPackageIndex ->
                        Either String ([Dependency],
-                                      Map PackageName InstalledPackageInfo)
+                                      Map (PackageName, ComponentName) InstalledPackageInfo)
 combinedConstraints constraints dependencies installedPackages = do
 
     when (not (null badComponentIds)) $
@@ -1376,21 +1376,21 @@ combinedConstraints constraints dependencies installedPackages = do
     allConstraints :: [Dependency]
     allConstraints = constraints
                   ++ [ thisPackageVersion (packageId pkg)
-                     | (_, _, Just pkg) <- dependenciesPkgInfo ]
+                     | (_, _, _, Just pkg) <- dependenciesPkgInfo ]
 
-    idConstraintMap :: Map PackageName InstalledPackageInfo
+    idConstraintMap :: Map (PackageName, ComponentName) InstalledPackageInfo
     idConstraintMap = Map.fromList
                         -- NB: do NOT use the packageName from
                         -- dependenciesPkgInfo!
-                        [ (pn, pkg)
-                        | (pn, _, Just pkg) <- dependenciesPkgInfo ]
+                        [ ((pn, cname), pkg)
+                        | (pn, cname, _, Just pkg) <- dependenciesPkgInfo ]
 
     -- The dependencies along with the installed package info, if it exists
-    dependenciesPkgInfo :: [(PackageName, ComponentId,
+    dependenciesPkgInfo :: [(PackageName, ComponentName, ComponentId,
                              Maybe InstalledPackageInfo)]
     dependenciesPkgInfo =
-      [ (pkgname, cid, mpkg)
-      | (pkgname, cid) <- dependencies
+      [ (pkgname, cname, cid, mpkg)
+      | (pkgname, cname, cid) <- dependencies
       , let mpkg = PackageIndex.lookupComponentId
                      installedPackages cid
       ]
@@ -1399,13 +1399,19 @@ combinedConstraints constraints dependencies installedPackages = do
     -- (i.e. someone has written a hash) and didn't find it then it's
     -- an error.
     badComponentIds =
-      [ (pkgname, cid)
-      | (pkgname, cid, Nothing) <- dependenciesPkgInfo ]
+      [ (pkgname, cname, cid)
+      | (pkgname, cname, cid, Nothing) <- dependenciesPkgInfo ]
 
     dispDependencies deps =
       hsep [    text "--dependency="
-             <<>> quotes (disp pkgname <<>> char '=' <<>> disp cid)
-           | (pkgname, cid) <- deps ]
+             <<>> quotes
+                    (disp pkgname
+                    <<>> case cname of CLibName -> ""
+                                       CSubLibName n -> ":" <<>> disp n
+                                       _ -> ":" <<>> disp cname
+                    <<>> char '='
+                    <<>> disp cid)
+           | (pkgname, cname, cid) <- deps ]
 
 -- -----------------------------------------------------------------------------
 -- Configuring program dependencies

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -88,6 +88,7 @@ import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.ForeignLibOption
+import Distribution.Types.GivenComponent
 import Distribution.Types.Mixin
 import Distribution.Types.UnqualComponentName
 import Distribution.Simple.Utils
@@ -1357,7 +1358,7 @@ interpretPackageDbFlags userInstall specificDBs =
 -- deps in the end. So we still need to remember which installed packages to
 -- pick.
 combinedConstraints :: [Dependency] ->
-                       [(PackageName, ComponentName, ComponentId)] ->
+                       [GivenComponent] ->
                        InstalledPackageIndex ->
                        Either String ([Dependency],
                                       Map (PackageName, ComponentName) InstalledPackageInfo)
@@ -1390,7 +1391,7 @@ combinedConstraints constraints dependencies installedPackages = do
                              Maybe InstalledPackageInfo)]
     dependenciesPkgInfo =
       [ (pkgname, cname, cid, mpkg)
-      | (pkgname, cname, cid) <- dependencies
+      | GivenComponent pkgname cname cid <- dependencies
       , let mpkg = PackageIndex.lookupComponentId
                      installedPackages cid
       ]

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -102,6 +102,7 @@ import Distribution.Verbosity
 import Distribution.Utils.NubList
 import Distribution.Types.Dependency
 import Distribution.Types.ComponentId
+import Distribution.Types.GivenComponent
 import Distribution.Types.Module
 import Distribution.Types.PackageName
 import Distribution.Types.UnqualComponentName (unUnqualComponentName)
@@ -257,7 +258,7 @@ data ConfigFlags = ConfigFlags {
     configStripLibs :: Flag Bool,      -- ^Enable library stripping
     configConstraints :: [Dependency], -- ^Additional constraints for
                                        -- dependencies.
-    configDependencies :: [(PackageName, ComponentName, ComponentId)],
+    configDependencies :: [GivenComponent],
       -- ^The packages depended on.
     configInstantiateWith :: [(ModuleName, Module)],
       -- ^ The requested Backpack instantiation.  If empty, either this
@@ -647,8 +648,8 @@ configureOptions showOrParseArgs =
          "A list of exact dependencies. E.g., --dependency=\"void=void-0.5.8-177d5cdf20962d0581fe2e4932a6c309\""
          configDependencies (\v flags -> flags { configDependencies = v})
          (reqArg "NAME[:COMPONENT_NAME]=CID"
-                 (parsecToReadE (const "dependency expected") ((\x -> [x]) `fmap` parsecDependency))
-                 (map (\(pn, cn, cid) ->
+                 (parsecToReadE (const "dependency expected") ((\x -> [x]) `fmap` parsecGivenComponent))
+                 (map (\(GivenComponent pn cn cid) ->
                      display pn
                      ++ case cn of CLibName -> ""
                                    CSubLibName n -> ":" ++ display n
@@ -735,8 +736,8 @@ showProfDetailLevelFlag :: Flag ProfDetailLevel -> [String]
 showProfDetailLevelFlag NoFlag    = []
 showProfDetailLevelFlag (Flag dl) = [showProfDetailLevel dl]
 
-parsecDependency :: ParsecParser (PackageName, ComponentName, ComponentId)
-parsecDependency = do
+parsecGivenComponent :: ParsecParser GivenComponent
+parsecGivenComponent = do
   pn <- parsec
   cn <- P.option CLibName $ do
     _ <- P.char ':'
@@ -746,7 +747,7 @@ parsecDependency = do
              else CSubLibName ucn
   _ <- P.char '='
   cid <- parsec
-  return (pn, cn, cid)
+  return $ GivenComponent pn cn cid
 
 installDirsOptions :: [OptionField (InstallDirs (Flag PathTemplate))]
 installDirsOptions =

--- a/Cabal/Distribution/Types/GivenComponent.hs
+++ b/Cabal/Distribution/Types/GivenComponent.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.GivenComponent (
+  GivenComponent(..)
+) where
+
+import Distribution.Compat.Prelude
+
+import Distribution.Types.ComponentId
+import Distribution.Types.ComponentName
+import Distribution.Types.PackageName
+
+-- | A 'GivenComponent' represents a component depended on and explicitly
+-- specified by the user/client with @--dependency@
+--
+-- It enables Cabal to know which 'ComponentId' to associate with a component
+--
+-- @since 2.3.0.0
+data GivenComponent =
+  GivenComponent
+    { givenComponentPackage :: PackageName
+    , givenComponentName    :: ComponentName
+    , givenComponentId      :: ComponentId }
+  deriving (Generic, Read, Show, Eq, Typeable)
+
+instance Binary GivenComponent
+

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -64,6 +64,8 @@ import Distribution.Package
          ( Package(..), packageName, PackageId )
 import Distribution.Types.Dependency
          ( Dependency(..), thisPackageVersion )
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
 import qualified Distribution.PackageDescription as PkgDesc
 import Distribution.PackageDescription.Parsec
          ( readGenericPackageDescription )
@@ -402,7 +404,7 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ (packageName srcid, PkgDesc.CLibName, uid)
+      configDependencies = [ GivenComponent (packageName srcid) (PkgDesc.CLibName) uid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -402,7 +402,7 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ (packageName srcid, uid)
+      configDependencies = [ (packageName srcid, PkgDesc.CLibName, uid)
                            | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -404,8 +404,8 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ GivenComponent (packageName srcid) (PkgDesc.CLibName) uid
-                           | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
+      configDependencies = [ GivenComponent (packageName srcid) cname uid
+                           | ConfiguredId srcid (Just cname) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,
       configVerbosity          = toFlag verbosity,

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1246,8 +1246,8 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ GivenComponent (packageName srcid) PackageDescription.CLibName dep_ipid
-                         | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
+    configDependencies = [ GivenComponent (packageName srcid) cname dep_ipid
+                         | ConfiguredId srcid (Just cname) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.
     configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1244,7 +1244,7 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ (packageName srcid, dep_ipid)
+    configDependencies = [ (packageName srcid, PackageDescription.CLibName, dep_ipid)
                          | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -143,6 +143,8 @@ import Distribution.Package
          , UnitId )
 import Distribution.Types.Dependency
          ( Dependency(..), thisPackageVersion )
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
 import Distribution.Types.MungedPackageId
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription
@@ -1244,7 +1246,7 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ (packageName srcid, PackageDescription.CLibName, dep_ipid)
+    configDependencies = [ GivenComponent (packageName srcid) PackageDescription.CLibName dep_ipid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3291,6 +3291,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
                                         | packageId elab == srcid
                                         -> mkPackageName (unUnqualComponentName uqn)
                                     _ -> packageName srcid,
+                                   CLibName,
                                    cid)
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -112,6 +112,8 @@ import           Distribution.Package hiding
   (InstalledPackageId, installedPackageId)
 import           Distribution.Types.AnnotatedId
 import           Distribution.Types.ComponentName
+import           Distribution.Types.GivenComponent
+  (GivenComponent(..))
 import           Distribution.Types.PkgconfigDependency
 import           Distribution.Types.UnqualComponentName
 import           Distribution.System
@@ -3285,14 +3287,15 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     -- NB: This does NOT use InstallPlan.depends, which includes executable
     -- dependencies which should NOT be fed in here (also you don't have
     -- enough info anyway)
-    configDependencies        = [ (case mb_cn of
-                                    -- Special case for internal libraries
-                                    Just (CSubLibName uqn)
-                                        | packageId elab == srcid
-                                        -> mkPackageName (unUnqualComponentName uqn)
-                                    _ -> packageName srcid,
-                                   CLibName,
-                                   cid)
+    configDependencies        = [ GivenComponent
+                                    (case mb_cn of
+                                       -- Special case for internal libraries
+                                       Just (CSubLibName uqn)
+                                           | packageId elab == srcid
+                                           -> mkPackageName (unUnqualComponentName uqn)
+                                       _ -> packageName srcid)
+                                     CLibName
+                                     cid
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =
         case elabPkgOrComp of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3288,14 +3288,9 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     -- dependencies which should NOT be fed in here (also you don't have
     -- enough info anyway)
     configDependencies        = [ GivenComponent
-                                    (case mb_cn of
-                                       -- Special case for internal libraries
-                                       Just (CSubLibName uqn)
-                                           | packageId elab == srcid
-                                           -> mkPackageName (unUnqualComponentName uqn)
-                                       _ -> packageName srcid)
-                                     CLibName
-                                     cid
+                                    (packageName srcid)
+                                    (fromMaybe CLibName mb_cn)
+                                    cid
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =
         case elabPkgOrComp of

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -110,8 +110,13 @@ import Distribution.Simple.InstallDirs
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
 import Distribution.Package
-         ( PackageIdentifier, PackageName, packageName, packageVersion )
+         ( PackageIdentifier, PackageName, packageName, mkPackageName
+         , packageVersion )
 import Distribution.Types.Dependency
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
+import Distribution.Types.UnqualComponentName
+         ( unUnqualComponentName )
 import Distribution.PackageDescription
          ( BuildType(..), RepoKind(..), ComponentName(..) )
 import Distribution.System ( Platform )
@@ -525,9 +530,15 @@ filterConfigureFlags flags cabalLibVersion
       -- Cabal < 2.5.0 does not understand --dependency=pkg:COMPONENT=cid
       --                                   (public sublibraries)
       configDependencies =
-        let isMainLib CLibName = True
-            isMainLib _        = False
-        in filter (\(_, c, _) -> isMainLib c) $ configDependencies flags
+        let convertToLegacyInternalDep (GivenComponent _ (CSubLibName cn) cid) =
+              Just $ GivenComponent
+                       (mkPackageName $ unUnqualComponentName cn)
+                       CLibName
+                       cid
+            convertToLegacyInternalDep (GivenComponent pn CLibName cid) =
+              Just $ GivenComponent pn CLibName cid
+            convertToLegacyInternalDep _ = Nothing
+        in catMaybes $ convertToLegacyInternalDep <$> configDependencies flags
       }
 
     flags_2_1_0 = flags_2_5_0 {

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -113,7 +113,7 @@ import Distribution.Package
          ( PackageIdentifier, PackageName, packageName, packageVersion )
 import Distribution.Types.Dependency
 import Distribution.PackageDescription
-         ( BuildType(..), RepoKind(..) )
+         ( BuildType(..), RepoKind(..), ComponentName(..) )
 import Distribution.System ( Platform )
 import Distribution.Text
          ( Text(..), display )
@@ -495,7 +495,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [2,1,0]  = flags_latest
+  | cabalLibVersion >= mkVersion [2,3,0]  = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -513,6 +513,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
   | cabalLibVersion < mkVersion [1,25,0] = flags_1_25_0
   | cabalLibVersion < mkVersion [2,1,0]  = flags_2_1_0
+  | cabalLibVersion < mkVersion [2,5,0]  = flags_2_5_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -520,7 +521,16 @@ filterConfigureFlags flags cabalLibVersion
       configConstraints = []
       }
 
-    flags_2_1_0 = flags_latest {
+    flags_2_5_0 = flags_latest {
+      -- Cabal < 2.5.0 does not understand --dependency=pkg:COMPONENT=cid
+      --                                   (public sublibraries)
+      configDependencies =
+        let isMainLib CLibName = True
+            isMainLib _        = False
+        in filter (\(_, c, _) -> isMainLib c) $ configDependencies flags
+      }
+
+    flags_2_1_0 = flags_2_5_0 {
       -- Cabal < 2.1 doesn't know about -v +timestamp modifier
         configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
       -- Cabal < 2.1 doesn't know about --<enable|disable>-static


### PR DESCRIPTION
The old --dependency could only do --dependency=pkg=cid,
but with public sublibraries this will become insufficient.

Now there is the option to also specify a component name using
--dependency=pkg:component=cid

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
